### PR TITLE
Fix: Fixed an api endpoint allowed method

### DIFF
--- a/FusionIIIT/applications/central_mess/api/views.py
+++ b/FusionIIIT/applications/central_mess/api/views.py
@@ -603,11 +603,15 @@ class Get_Filtered_Students(APIView):
                 return response
 
 class Get_Reg_Records(APIView):
-
+    def get(self,request):
+        student_id = request.GET.get('student_id')
+        reg_record = Reg_records.objects.filter(student_id=student_id)
+        serialized_obj = reg_recordSerialzer(reg_record,many=True)
+        return Response({'payload':serialized_obj.data})
+    
     def post(self,request):
         student = request.data['student_id']
         reg_record = Reg_records.objects.filter(student_id=student)
-
         serialized_obj = reg_recordSerialzer(reg_record,many=True)
         return Response({'payload':serialized_obj.data}) 
 


### PR DESCRIPTION
## Issue that this pull request solves
On the registration page, We get an error because the frontend makes a **Get** request to the backend even though backend only allowed **Post** request. Instead of changing the **Post** to get that might affect other frontend pages, Just added a new **Get** method.